### PR TITLE
Register article bottom widget area

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -98,3 +98,48 @@ add_filter( 'script_loader_tag', function ( $tag, $handle ) {
 
     return str_replace( ' src', ' async src', $tag );
 }, 10, 2 );
+
+/**
+ * Register custom sidebars and other widget areas
+ * 
+ * @see https://github.com/INN/largo/blob/590181982d22a5444eb3c5ccca58ea8b56db12f7/inc/sidebars.php#L3-L129
+ */
+function calhealth_register_custom_sidebars() {
+
+	$sidebars = array(
+
+		array(
+			'name' 	=> __( 'Article Bottom', 'allonsy' ),
+			'desc' 	=> __( 'Footer widget area for posts', 'allonsy' ),
+			'id' 	=> 'article-bottom'
+		),
+
+	);
+
+	// register the active widget areas
+	foreach ( $sidebars as $sidebar ) {
+		register_sidebar( array(
+			'name' 			=> $sidebar['name'],
+			'description' 	=> $sidebar['desc'],
+			'id' 			=> $sidebar['id'],
+			'before_widget' => '<!-- Sidebar: ' . $sidebar['id'] . ' --><aside id="%1$s" class="%2$s clearfix side-widget">',
+			'after_widget' 	=> "</aside>",
+			'before_title' 	=> '<h3 class="widgettitle">',
+			'after_title' 	=> '</h3>',
+		) );
+	}
+
+}
+add_action( 'widgets_init', 'calhealth_register_custom_sidebars' );
+
+/**
+ * If the article bottom widget area has active widgets, go ahead and show it
+ * 
+ * @see https://github.com/INN/umbrella-elpasomatters/issues/3
+ */
+function calhealth_post_bottom_widget_area() {
+	if ( is_active_sidebar( 'article-bottom' ) ) {
+		dynamic_sidebar( 'article-bottom' );
+	}
+}
+add_action( 'calhealth_post_bottom_widget_area', 'calhealth_post_bottom_widget_area' );

--- a/single.php
+++ b/single.php
@@ -76,6 +76,13 @@ if( get_theme_mod('internal-title-bar') != '' ) {
 
 <?php do_action( 'foundationpress_after_content' ); ?>
 <?php if( $hide_sidebar != 'yes' ) : get_sidebar('posts'); endif; ?>
+<?php 
+
+	// custom article bottom widget area
+	// added for https://github.com/INN/theme-calhealthreport/issues/15
+	do_action( 'calhealth_post_bottom_widget_area' ); 
+
+?>
 </div>
 <?php get_template_part( 'template-parts/related-posts' ); ?>
 <?php get_footer();


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Registers an `Article Bottom` widget area so we can put the republication button at the end of posts

![screencapture-calhealth-test-2020-05-12-at-high-risk-from-coronavirus-undocumented-seniors-fear-seeking-medical-care-2020-05-21-10_15_17](https://user-images.githubusercontent.com/18353636/82567972-22affc80-9b4c-11ea-8d5d-c88d1b866ddc.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #15

## Testing/Questions

Features that this PR affects:

- `single.php` post template + new widget area

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Is `allonsy` the correct domain to use in the `__()` translation function?

Steps to test this PR:

1. Add the republication widget to the new `Article Bottom` widget area
2. View it on an article and make sure everything looks ok