### PR TITLE
Add metabox and other functions for subhead

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -56,6 +56,9 @@ require_once( 'library/bs-custom-functions.php' );
 /** Customizer Additions */
 require_once( 'library/bs-customizer-additions.php' );
 
+/** The "Subhead" metabox and related functions */
+require_once( 'library/metabox-subhead.php' );
+
 /** Required and Recommended Plugins */
 require_once( 'library/class-tgm-plugin-activation.php' );
 require_once( 'library/bs-plugin-activation.php' );

--- a/library/metabox-subhead.php
+++ b/library/metabox-subhead.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Functions related to meta boxes
+ */
+
+/**
+ * Output the subtitle metabox.
+ *
+ * @link Copied from https://github.com/INN/umbrella-wcij/blob/16247cdd8f03a593633c82f8836c4c1e8aa83987/wp-content/themes/wisconsinwatch/inc/metaboxes.php with improvements
+ */
+function subtitle_meta_box_display() {
+	global $post;
+	$values = get_post_custom( $post->ID );
+	wp_nonce_field( 'largo_meta_box_nonce', 'meta_box_nonce' );
+	?>
+		<label for="subtitle"><?php esc_html_e( 'Subtitle', 'largo' ); ?></label>
+		<textarea name="subtitle" id="subtitle" class="widefat" rows="2" cols="20"><?php
+			// PHP open/close are at the textarea boundary so we don't prepend/append this with tabs.
+			if ( isset( $values['subtitle'] ) ) {
+				echo wp_kses_post( $values['subtitle'][0] );
+			}
+		?></textarea>
+		<p><small><?php esc_html_e( 'HTML tags that are allowed in posts are allowed in this area.', 'largo' ); ?></small></p>
+	<?php
+}
+/**
+ * Register our subtitle metabox
+ *
+ * This doesn't have anything special applied to it for Gutenberg.
+ * If Publicsource switches to Gutenberg, read https://developer.wordpress.org/block-editor/developers/backward-compatibility/meta-box/ and update this box as necessary.
+ */
+add_action(
+	'init',
+	function() {
+		largo_add_meta_box(
+			'subtitle',
+			'Subtitle',
+			'subtitle_meta_box_display',
+			'post',
+			'normal',
+			'high'
+		);
+		largo_register_meta_input( 'subtitle', 'wp_filter_post_kses' );
+	}
+);

--- a/library/metabox-subhead.php
+++ b/library/metabox-subhead.php
@@ -4,6 +4,26 @@
  */
 
 /**
+ * Register the 'subtitle' post meta
+ */
+function subtitle_meta_box_register_post_meta() {
+	return register_post_meta(
+		'post',
+		'subtitle',
+		array(
+			'object_subtype' => 'post',
+			'type' => 'string',
+			'description' => __( 'The subhead, deck, subtitle, or lead is a preface shown on article pages below the main title.' , 'allonsy' ),
+			'single' => true,
+			'sanitize_callback' => 'sanitize_textarea_field',
+			// 'auth_callback' => '',
+			'show_in_rest' => true,
+		),
+	);
+}
+add_action( 'init', 'subtitle_meta_box_register_post_meta' );
+
+/**
  * Output the subtitle metabox.
  *
  * @link Copied from https://github.com/INN/umbrella-wcij/blob/16247cdd8f03a593633c82f8836c4c1e8aa83987/wp-content/themes/wisconsinwatch/inc/metaboxes.php with improvements
@@ -33,7 +53,13 @@ function subtitle_meta_box_display() {
  * @return null
  */
 function subtitle_meta_box_save( $post_id, $post, $update = false ) {
+	if ( ! isset( $_POST['subtitle_meta_box_nonce'] ) ) {
+		error_log(var_export( 'subtitle meta box nonce not set', true));
+		return;
+	}
+
 	if ( ! wp_verify_nonce( $_POST['subtitle_meta_box_nonce'], $_POST['subtitle_meta_box_nonce'] ) ) {
+		error_log(var_export( 'subtitle meta box nonce not valid', true));
 		return;
 	}
 

--- a/library/metabox-subhead.php
+++ b/library/metabox-subhead.php
@@ -32,7 +32,7 @@ function subtitle_meta_box_display() {
  * @param bool    $update whether the post is being updated
  * @return null
  */
-function subtitle_meta_box_save( $post_id, $post, $update ) {
+function subtitle_meta_box_save( $post_id, $post, $update = false ) {
 	if ( ! wp_verify_nonce( $_POST['subtitle_meta_box_nonce'], $_POST['subtitle_meta_box_nonce'] ) ) {
 		return;
 	}
@@ -60,7 +60,7 @@ function subtitle_meta_box_save( $post_id, $post, $update ) {
 
 	return $subtitle;
 }
-add_action( 'save_post', 'subtitle_meta_box_save', 10, 2 );
+add_action( 'save_post', 'subtitle_meta_box_save', 10, 3 );
 
 /**
  * Register our subtitle metabox

--- a/library/metabox-subhead.php
+++ b/library/metabox-subhead.php
@@ -33,14 +33,14 @@ function subtitle_meta_box_display() {
 	$values = get_post_custom( $post->ID );
 	wp_nonce_field( 'subtitle_meta_box_nonce', 'subtitle_meta_box_nonce' );
 	?>
-		<label for="subtitle"><?php esc_html_e( 'Subtitle', 'largo' ); ?></label>
+		<label for="subtitle" class="screen-reader-text"><?php esc_html_e( 'Subtitle', 'largo' ); ?></label>
 		<textarea name="subtitle" id="subtitle" class="widefat" rows="2" cols="20"><?php
 			// PHP open/close are at the textarea boundary so we don't prepend/append this with tabs.
 			if ( isset( $values['subtitle'] ) ) {
-				echo wp_kses_post( $values['subtitle'][0] );
+				echo sanitize_text_field( $values['subtitle'][0] );
 			}
 		?></textarea>
-		<p><small><?php esc_html_e( 'HTML tags that are allowed in posts are allowed in this area.', 'largo' ); ?></small></p>
+		<p><small><?php esc_html_e( 'Plain text is allowed in the post subtitle.', 'largo' ); ?></small></p>
 	<?php
 }
 

--- a/library/metabox-subhead.php
+++ b/library/metabox-subhead.php
@@ -58,7 +58,7 @@ function subtitle_meta_box_save( $post_id, $post, $update = false ) {
 		return;
 	}
 
-	if ( ! wp_verify_nonce( $_POST['subtitle_meta_box_nonce'], $_POST['subtitle_meta_box_nonce'] ) ) {
+	if ( ! wp_verify_nonce( $_POST['subtitle_meta_box_nonce'], 'subtitle_meta_box_nonce' ) ) {
 		error_log(var_export( 'subtitle meta box nonce not valid', true));
 		return;
 	}

--- a/library/metabox-subhead.php
+++ b/library/metabox-subhead.php
@@ -76,7 +76,6 @@ function subtitle_meta_box_save( $post_id, $post, $update = false ) {
 	}
 
 	$subtitle = wp_kses_post( $_POST['subtitle'] );
-	error_log(var_export( $subtitle, true));
 
 	if ( ! empty( $subtitle ) ) {
 		update_post_meta( $post_id, 'subtitle', $subtitle );

--- a/single.php
+++ b/single.php
@@ -28,6 +28,13 @@ if( get_theme_mod('internal-title-bar') != '' ) {
 	<section <?php post_class('main-content') ?> id="post-<?php the_ID(); ?>">
     <?php if( get_theme_mod('internal-title-bar') == '' ) { ?>
       <h1 class="entry-title"><?php the_title(); ?></h1>
+      <?php
+        $subtitle = get_post_custom_values( 'subtitle', get_the_ID() );
+        printf(
+          '<pre><code>%1$s</code></pre>',
+          var_export( $subtitle, true )
+        );
+      ?>
       <?php if( get_theme_mod('about-the-author') != '' ): ?>
         <div class="post-meta"><p><span class="author-name author-date">By <a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" title="<?php echo esc_attr( get_the_author() ); ?>"><?php the_author(); ?></a> • <?php echo get_the_date( 'M j, Y', $post->ID ); ?></span></p></div>
       <?php endif; ?>

--- a/single.php
+++ b/single.php
@@ -30,10 +30,17 @@ if( get_theme_mod('internal-title-bar') != '' ) {
       <h1 class="entry-title"><?php the_title(); ?></h1>
       <?php
         $subtitle = get_post_custom_values( 'subtitle', get_the_ID() );
-        printf(
-          '<pre><code>%1$s</code></pre>',
-          var_export( $subtitle, true )
-        );
+        if ( ! empty( $subtitle ) ) {
+          // should be single value post meta, but if it isn't....
+          if ( is_array( $subtitle ) ) {
+            $subtitle = $subtitle[0];
+          }
+
+          printf(
+            '<h2 class="subtitle">%1$s</h2>',
+            esc_html( $subtitle ),
+          );
+        }
       ?>
       <?php if( get_theme_mod('about-the-author') != '' ): ?>
         <div class="post-meta"><p><span class="author-name author-date">By <a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" title="<?php echo esc_attr( get_the_author() ); ?>"><?php the_author(); ?></a> • <?php echo get_the_date( 'M j, Y', $post->ID ); ?></span></p></div>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- adds a meta box for the subtitle
- provides a version of the solution for this problem in Largo (https://github.com/INN/largo/issues/1730) that doesn't involve reliance on Largo's functions, because this is not a Largo child theme.
- tests the subtitle output on posts with `$subtitle = get_post_custom_values( 'subtitle', get_the_ID() );`

![Screen Shot 2020-06-02 at 23 22 50](https://user-images.githubusercontent.com/1754187/83592697-e9eb2c80-a528-11ea-97ae-6c37c99cdc53.png)
![Screen Shot 2020-06-02 at 23 29 01](https://user-images.githubusercontent.com/1754187/83592703-eb1c5980-a528-11ea-9450-3e42c8c18b5b.png)

No styles are included here; I'm waiting until #21 and the firmed-up subtitle styles from that.
![Screen Shot 2020-06-02 at 23 24 18](https://user-images.githubusercontent.com/1754187/83592702-ea83c300-a528-11ea-9920-e2a805aae7c0.png)



## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #14, as a version of https://github.com/INN/largo/issues/1730 that doesn't depend upon Largo

## Testing/Questions

Features that this PR affects:

- Editor for posts, in Gutenberg and Classic
- Single post template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Should we try to allow some HTML in the subtitle?

Steps to test this PR:

1. edit a post's subtitle, click "Update" or "Save". 
