### PR TITLE
Full width image article template

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -143,3 +143,34 @@ function calhealth_post_bottom_widget_area() {
 	}
 }
 add_action( 'calhealth_post_bottom_widget_area', 'calhealth_post_bottom_widget_area' );
+
+/**
+ * Enqueue needed files such as stylesheets and scripts
+ */
+function calhealth_stylesheets_and_scripts() {
+	wp_enqueue_style(
+		'calhealth',
+		get_stylesheet_directory_uri().'/style.css',
+		array(),
+		filemtime( get_stylesheet_directory().'/style.css' )
+	);
+}
+add_action( 'wp_enqueue_scripts', 'calhealth_stylesheets_and_scripts', 20 );
+
+/**
+ * Include theme files
+ *
+ * Based off of how Largo loads files: https://github.com/INN/largo/blob/v0.6.3/functions.php#L204-L208
+ *
+ */
+function calhealth_require_files() {
+	$includes = array(
+		'/inc/photo-header-template.php'
+	);
+	foreach ( $includes as $include ) {
+		if ( 0 === validate_file( get_stylesheet_directory() ) ) {
+			require_once( get_stylesheet_directory() . $include );
+		}
+	}
+}
+add_action( 'after_setup_theme', 'calhealth_require_files' ); 

--- a/inc/photo-header-template.php
+++ b/inc/photo-header-template.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Given an attachment ID, generate an opening <header> tag with an inline style attribute
+ * The inline style="" contains the background-image information for the photo header.
+ * The closing </header> tag is assumed to be present elsewhere in the markup.
+ * @param WP_Post|int the attachment image's post or ID
+ * @return string HTML
+ */
+function calhealth_photo_header_tag( $post = null ) {
+	$element_id = 'photo-header-' . (string) $post;
+	$selector = '#' . $element_id;
+
+	if ( $post ) {
+		echo '<style type="text/css">';
+
+		// this could be done with:
+		// 1. use get_intermediate_image_sizes to loop through all images with wp_get_attachment_image_src
+		// 2. Sort images by width ( $return[1] )
+		// 3. procedurally generate the media queries
+		// why we're not doing that:
+		// - wp_get_attachment_image_src hits the filesystem with each call
+		// - there's no reason to use half those image sizes
+		$sizes = array(
+			// registered image size name => width in pixels
+			// 'medium' => '336', // too small
+			// 'large' => '771',  // still too small
+			// 'two-third-full' => '780', // still too small
+			'rect_thumb' => '800', // this is 800x400 exact, we may not want to keep it
+			'full' => '1170',  
+		);
+
+		// loop through the image sizes and generate media queries!
+		$prior_size = 0;
+		foreach ( $sizes as $slug => $width ) {
+			$media_query = <<<'EOF'
+				@media (min-width: %1$spx) {
+					%3$s {
+						background-image: url(%4$s);
+					}
+				}
+EOF;
+			$return = wp_get_attachment_image_src( $post, $slug, false );
+			printf(
+				$media_query,
+				$prior_size,
+				$width,
+				$selector,
+				$return[0]
+			);
+			$prior_size = (int) $width + 1;
+		}
+
+		// and now the upper size case of media query
+		$media_query_biggest = <<<'EOF'
+			@media (min-width: %1$spx) {
+				%2$s {
+					background-image: url(%3$s);
+				}
+			}
+EOF;
+		$return = wp_get_attachment_url( $post );
+		printf(
+			$media_query_biggest,
+			$prior_size,
+			$selector,
+			$return
+		);
+
+		echo '</style>';
+
+	}
+
+	printf(
+		'<div id="%1$s" class="%2$s">',
+		$element_id,
+        $post ? "photo-header-background" : "photo-header-background no-photo"
+    );
+
+}

--- a/single-full-width-image.php
+++ b/single-full-width-image.php
@@ -17,20 +17,24 @@ if( get_theme_mod('internal-title-bar') != '' ) {
 <?php if( get_theme_mod('internal-breadcrumbs') != '' ) {
   if ( function_exists('yoast_breadcrumb') ) { yoast_breadcrumb('<nav class="max-width-twelve-hundred" aria-label="You are here:" role="navigation"> <ul class="breadcrumbs">','</ul></nav>'); }
 } ?>
-                <?php calhealth_photo_header_tag( get_post_thumbnail_id() ); ?>
-                <div class="featured-image-bg-layer">
-                </div>
-                <div class="featured-image-container-content">
-                    <?php
+<?php calhealth_photo_header_tag( get_post_thumbnail_id() ); ?>
+<div class="featured-image-bg-layer">
+</div>
+<div class="featured-image-container-content">
+    <?php
 
-                    if( get_post_thumbnail_id() ) {
-                        echo '<div class="featured-image-wrapper"><img class="featured-image-container-mobile-image" src="'.wp_get_attachment_url( get_post_thumbnail_id() ).'"></div>';
-                    }
+    if( get_post_thumbnail_id() ) {
+        echo '<div class="featured-image-wrapper"><img class="featured-image-container-mobile-image" src="'.wp_get_attachment_url( get_post_thumbnail_id() ).'"></div>';
+    }
 
-                    ?>
-                    <h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
-                </div>
-                </div>
+    ?>
+    <figcaption><em><?php the_post_thumbnail_caption(); ?></em></figcaption>
+    <h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
+    <?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
+        <h2 class="subtitle"><?php echo $subtitle ?></h2>
+    <?php endif; ?>
+</div>
+</div>
 <div id="single-post" class="page-full-width max-width-one-thousand <?php if( isset($hide_sidebar) && $hide_sidebar == 'yes' ) { echo 'no-sidebar'; } ?>" role="main">
 
 <?php do_action( 'foundationpress_before_content' ); ?>
@@ -44,9 +48,6 @@ if( get_theme_mod('internal-title-bar') != '' ) {
         <?php do_action( 'foundationpress_post_before_entry_content' ); ?>
         <div class="bottom-header-content">
             <figcaption><em><?php the_post_thumbnail_caption(); ?></em></figcaption>
-            <?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
-                <h2 class="subtitle"><?php echo $subtitle ?></h2>
-            <?php endif; ?>
             <div class="bottom-header-inline-content">
                 <?php if( get_theme_mod('about-the-author') != '' ): ?>
                     <div class="post-meta"><p><span class="author-name author-date">By <a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" title="<?php echo esc_attr( get_the_author() ); ?>"><?php the_author(); ?></a> • <?php echo get_the_date( 'M j, Y', $post->ID ); ?></span></p></div>

--- a/single-full-width-image.php
+++ b/single-full-width-image.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Template Name: Full Width Header Image
+ * Description: The template for displaying all single posts and attachments with a full width image in the header
+ * Template Post Type: post
+ *
+ */
+
+get_header();
+
+$hide_sidebar = get_field('hide_sidebar');
+
+if( get_theme_mod('internal-title-bar') != '' ) {
+  get_template_part( 'template-parts/title-bar' );
+} ?>
+
+<?php if( get_theme_mod('internal-breadcrumbs') != '' ) {
+  if ( function_exists('yoast_breadcrumb') ) { yoast_breadcrumb('<nav class="max-width-twelve-hundred" aria-label="You are here:" role="navigation"> <ul class="breadcrumbs">','</ul></nav>'); }
+} ?>
+                <?php calhealth_photo_header_tag( get_post_thumbnail_id() ); ?>
+                <div class="featured-image-bg-layer">
+                </div>
+                <div class="featured-image-container-content">
+                    <?php
+
+                    if( get_post_thumbnail_id() ) {
+                        echo '<div class="featured-image-wrapper"><img class="featured-image-container-mobile-image" src="'.wp_get_attachment_url( get_post_thumbnail_id() ).'"></div>';
+                    }
+
+                    ?>
+                    <h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
+                </div>
+                </div>
+<div id="single-post" class="page-full-width max-width-one-thousand <?php if( isset($hide_sidebar) && $hide_sidebar == 'yes' ) { echo 'no-sidebar'; } ?>" role="main">
+
+<?php do_action( 'foundationpress_before_content' ); ?>
+<?php while ( have_posts() ) : the_post();
+
+  $hide_featured_image = get_field('bs_hide_featured_image');?>
+
+	<section <?php post_class('main-content') ?> id="post-<?php the_ID(); ?>">
+    <?php if( get_theme_mod('internal-title-bar') == '' ) { ?>
+    <?php } ?>
+        <?php do_action( 'foundationpress_post_before_entry_content' ); ?>
+        <div class="bottom-header-content">
+            <figcaption><em><?php the_post_thumbnail_caption(); ?></em></figcaption>
+            <?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
+                <h2 class="subtitle"><?php echo $subtitle ?></h2>
+            <?php endif; ?>
+            <div class="bottom-header-inline-content">
+                <?php if( get_theme_mod('about-the-author') != '' ): ?>
+                    <div class="post-meta"><p><span class="author-name author-date">By <a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" title="<?php echo esc_attr( get_the_author() ); ?>"><?php the_author(); ?></a> • <?php echo get_the_date( 'M j, Y', $post->ID ); ?></span></p></div>
+                <?php endif; ?>
+            </div>
+        </div>
+		<div class="entry-content">
+
+		<?php the_content(); ?>
+		</div>
+
+		<?php if( get_theme_mod('show-post-tags') != '' ) {
+		$posttags = get_the_tags(); if ($posttags) { ?>
+		<div class="the-tags">
+			<hr>
+			<h6>Post Tags</h6>
+			<?php foreach($posttags as $tag) {
+				echo '<a href="' . get_bloginfo('url') . '/tag/'  . $tag->slug . '"><span class="tag">#' . $tag->slug . '</a></span>';
+			} ?>
+		</div>
+		<?php } } ?>
+
+		<?php if( get_theme_mod('about-the-author') == '' ) {
+		get_template_part( 'template-parts/about-author' );
+		} ?>
+
+		<!-- <nav id="nav-single" class="nav-single">
+			<div class="nav-single-inner">
+				<span class="nav-previous"><?php next_post_link( '%link', '<span class="meta-nav">' . _x( '&laquo;', 'Previous post link', 'allonsy' ) . '</span> %title' ); ?></span>
+				<span class="nav-next"><?php previous_post_link( '%link', '%title <span class="meta-nav">' . _x( '&raquo;', 'Next post link', 'allonsy' ) . '</span>' ); ?></span>
+			</div>
+		</nav> --> <!-- .nav-single -->
+		<?php /*
+      do_action( 'foundationpress_post_before_comments' );
+      comments_template();
+      do_action( 'foundationpress_post_after_comments' );
+    */ ?>
+	</section>
+<?php endwhile;?>
+
+<?php do_action( 'foundationpress_after_content' ); ?>
+<?php if( $hide_sidebar != 'yes' ) : get_sidebar('posts'); endif; ?>
+<?php 
+
+	// custom article bottom widget area
+	// added for https://github.com/INN/theme-calhealthreport/issues/15
+	do_action( 'calhealth_post_bottom_widget_area' ); 
+
+?>
+</div>
+<?php get_template_part( 'template-parts/related-posts' ); ?>
+<?php get_footer();

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body:not(.home).single .entry-content a,
 body:not(.home).single .entry-content li, 
 body:not(.home).single .entry-content p, 
 body:not(.home).single .entry-content span {
-  font-size: 1.13rem!important;
+  font-size: 1.25rem!important;
 }
 .post-template-single-full-width-image .photo-header-background {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -34,3 +34,66 @@ License URI:        http://www.opensource.org/licenses/mit-license.php
   you could just enqueue this file (style.css) to the header and add your styles in this file
 
 ---------------------------------------------------------------------------- */
+
+/* Single Posts */
+body:not(.home).single .entry-content a, 
+body:not(.home).single .entry-content li, 
+body:not(.home).single .entry-content p, 
+body:not(.home).single .entry-content span {
+  font-size: 1.13rem!important;
+}
+.post-template-single-full-width-image .photo-header-background {
+  display: flex;
+  /* justify-content: center; */
+  align-items: flex-end;
+  padding: 3rem;
+  min-height: 675px;
+  height: max-content;
+  margin-left: calc(50% - 50vw) !important;
+  max-width: 100vw;
+  width: 100vw;
+  background-repeat: no-repeat;
+  background-size: cover;
+  margin-top: 0!important;
+}
+.post-template-single-full-width-image .photo-header-background h1.entry-title {
+  color: #fff;
+  font-size: 2rem;
+  max-width: 80%;
+}
+.post-template-single-full-width-image .photo-header-background .featured-image-container-content .featured-image-container-mobile-image {
+  margin-bottom: 30px;
+}
+.post-template-single-full-width-image .bottom-header-content figcaption {
+  margin-bottom: 2rem;
+}
+.post-template-single-full-width-image #single-post {
+  margin-top: 1rem;
+}
+@media (max-width: 768px) {
+  .post-template-single-full-width-image .photo-header-background {
+    display: block;
+    background-image: none!important;
+    min-height: auto;
+    padding: 0;
+  }
+  .post-template-single-full-width-image .photo-header-background h1.entry-title {
+    color: #000;
+    padding: 0 1rem;
+    max-width: inherit;
+  }
+}
+@media (min-width: 768px) {
+  .post-template-single-full-width-image .featured-image-container-content .featured-image-container-mobile-image {
+    display: none;
+  }
+  .post-template-single-full-width-image .photo-header-background.no-photo {
+    background-color: rgba(0, 0, 0, 0.62);
+  }
+  .post-template-single-full-width-image .bottom-header-content figcaption {
+    margin-left: calc(50% - 48vw) !important;
+    max-width: 98vw;
+    width: 50vw;
+    margin-bottom: 3rem;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -61,6 +61,10 @@ body:not(.home).single .entry-content span {
   font-size: 2rem;
   max-width: 80%;
 }
+.post-template-single-full-width-image .photo-header-background h2.subtitle {
+  color: #fff;
+  max-width: 80%;
+}
 .post-template-single-full-width-image .photo-header-background .featured-image-container-content .featured-image-container-mobile-image {
   margin-bottom: 30px;
 }
@@ -77,10 +81,19 @@ body:not(.home).single .entry-content span {
     min-height: auto;
     padding: 0;
   }
-  .post-template-single-full-width-image .photo-header-background h1.entry-title {
+  .post-template-single-full-width-image .photo-header-background h1.entry-title,
+  .post-template-single-full-width-image .photo-header-background h2.subtitle {
     color: #000;
     padding: 0 1rem;
     max-width: inherit;
+  }
+  .post-template-single-full-width-image .bottom-header-content figcaption {
+    display: none;
+  }
+  .post-template-single-full-width-image .photo-header-background figcaption {
+    padding: 0 1rem;
+    max-width: inherit;
+    margin-bottom: 2rem;
   }
 }
 @media (min-width: 768px) {
@@ -89,6 +102,9 @@ body:not(.home).single .entry-content span {
   }
   .post-template-single-full-width-image .photo-header-background.no-photo {
     background-color: rgba(0, 0, 0, 0.62);
+  }
+  .post-template-single-full-width-image .photo-header-background figcaption {
+    display: none;
   }
   .post-template-single-full-width-image .bottom-header-content figcaption {
     margin-left: calc(50% - 48vw) !important;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a new template for posts to use to display a full-width image header area with overlaid title and subtitle
- Increases post body font size to 20px/1.25rem

Desktop:
![screencapture-calhealth-test-2020-05-19-this-crisis-has-led-to-more-equitable-policies-that-california-should-keep-2020-05-27-12_12_57](https://user-images.githubusercontent.com/18353636/83046001-5c817700-a014-11ea-8843-73be1716e1c0.png)

Mobile:
![screencapture-calhealth-test-2020-05-19-this-crisis-has-led-to-more-equitable-policies-that-california-should-keep-2020-05-27-12_12_34](https://user-images.githubusercontent.com/18353636/83045984-59868680-a014-11ea-9483-09d39e72c892.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #9

## Testing/Questions

Features that this PR affects:

- New full-width image template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Do we want to add in an opaque color overlay on the image? The title is sometimes hard to read, like in this example:
![Screen Shot 2020-05-27 at 12 17 44 PM](https://user-images.githubusercontent.com/18353636/83046125-8c307f00-a014-11ea-8590-3d491dc317bc.png)
- [ ] Most posts have the featured image in the post content but @MirandaEcho says not to worry about that and they'll take care of it on an individual basis while using this template https://github.com/INN/theme-calhealthreport/issues/9#issuecomment-632929569

Steps to test this PR:

1. Create/find a post and give it a featured image with a caption
2. Add in a title and subtitle
3. Select the new full width image template
4. View on frontend and make sure everything looks ok