### PR TITLE
Add background color overlay to full width featured image

### DIFF
--- a/style.css
+++ b/style.css
@@ -55,6 +55,7 @@ body:not(.home).single .entry-content span {
   background-repeat: no-repeat;
   background-size: cover;
   margin-top: 0!important;
+  position: relative;
 }
 .post-template-single-full-width-image .photo-header-background h1.entry-title {
   color: #fff;
@@ -64,6 +65,8 @@ body:not(.home).single .entry-content span {
 .post-template-single-full-width-image .photo-header-background h2.subtitle {
   color: #fff;
   max-width: 80%;
+  position: relative;
+  font-size: 1.75rem!important;
 }
 .post-template-single-full-width-image .photo-header-background .featured-image-container-content .featured-image-container-mobile-image {
   margin-bottom: 30px;
@@ -97,6 +100,14 @@ body:not(.home).single .entry-content span {
   }
 }
 @media (min-width: 768px) {
+  .post-template-single-full-width-image .photo-header-background .featured-image-bg-layer {
+    background-color: rgba(0, 0, 0, 0.62);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
   .post-template-single-full-width-image .featured-image-container-content .featured-image-container-mobile-image {
     display: none;
   }


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a color overlay on the new featured full-width image to improve title and subtitle readability
- Reduces the subtitle h2 font size by 1rem

Ex 1:
![screencapture-calhealth-test-2020-05-19-this-crisis-has-led-to-more-equitable-policies-that-california-should-keep-2020-06-02-09_45_26](https://user-images.githubusercontent.com/18353636/83529650-9f31cc00-a4b8-11ea-9ff4-5e3157cbf9e7.png)

Ex 2:
![screencapture-calhealth-test-2020-05-12-at-high-risk-from-coronavirus-undocumented-seniors-fear-seeking-medical-care-2020-06-02-10_06_12](https://user-images.githubusercontent.com/18353636/83529732-bd97c780-a4b8-11ea-8403-461b299745e8.png)

Mobile:
No changes from how it looks in #20 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #9

## Testing/Questions

Features that this PR affects:

- Full width featured image template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Is the color overlay too dark? Too light? Just right?

Steps to test this PR:

1. Follow the testing steps in #20 to generate an article with the featured full-width image
2. Make sure the color overlay looks ok