### PR TITLE
10 remove post bottom related stories

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -46,5 +46,4 @@ get_header(); ?>
 	</section>
 	<?php /* get_sidebar('archives'); */ ?>
 </div>
-<?php get_template_part( 'template-parts/related-posts' ); ?>
 <?php get_footer();

--- a/single-full-width-image.php
+++ b/single-full-width-image.php
@@ -98,5 +98,4 @@ if( get_theme_mod('internal-title-bar') != '' ) {
 
 ?>
 </div>
-<?php get_template_part( 'template-parts/related-posts' ); ?>
 <?php get_footer();

--- a/single.php
+++ b/single.php
@@ -98,5 +98,4 @@ if( get_theme_mod('internal-title-bar') != '' ) {
 
 ?>
 </div>
-<?php get_template_part( 'template-parts/related-posts' ); ?>
 <?php get_footer();

--- a/style.css
+++ b/style.css
@@ -155,3 +155,17 @@ body:not(.home) .pre-footer-widgets {
   font-weight: 700;
   line-height: 1.1;
 }
+/* https://github.com/INN/theme-calhealthreport/issues/13 */
+.wp-caption,
+.wp-caption > figcaption.wp-caption-text,
+figcaption {
+  font-style: italic;
+}
+.wp-caption em,
+.wp-caption > figcaption.wp-caption-text em,
+figcaption em,
+.wp-caption i,
+.wp-caption > figcaption.wp-caption-text i,
+figcaption i {
+  font-style: normal;
+}

--- a/style.css
+++ b/style.css
@@ -113,3 +113,45 @@ body:not(.home).single .entry-content span {
     margin-bottom: 3rem;
   }
 }
+
+
+/*
+ * footer widget area styles
+ *
+ * This copies a lot of styles from .bs-related-widgets
+ */
+body:not(.home) .pre-footer-widgets {
+  background: #eee;
+}
+.pre-footer-inner {
+  background: transparent;
+}
+.pre-footer-widgets .widget + .widget {
+  margin-top: 1.875rem;
+}
+.pre-footer-widgets .widget > h6 {
+  font-size: 1.875rem !important; /* ugh */
+}
+.pre-footer-widgets .related_posts_by_taxonomy ul { 
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-content: flex-start;
+  margin: 0;
+  padding: 0;
+}
+.pre-footer-widgets .related_posts_by_taxonomy li { 
+  flex: 1 1 18rem;
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+.pre-footer-widgets .related_posts_by_taxonomy li a { 
+  font-size: 1.25rem;
+  color: #000;
+  font-family: acumin-pro-condensed,"Arial Narrow",Arial,Helvetica,sans-serif !important;
+  font-weight: 700;
+  line-height: 1.1;
+}

--- a/style.css
+++ b/style.css
@@ -155,17 +155,3 @@ body:not(.home) .pre-footer-widgets {
   font-weight: 700;
   line-height: 1.1;
 }
-/* https://github.com/INN/theme-calhealthreport/issues/13 */
-.wp-caption,
-.wp-caption > figcaption.wp-caption-text,
-figcaption {
-  font-style: italic;
-}
-.wp-caption em,
-.wp-caption > figcaption.wp-caption-text em,
-figcaption em,
-.wp-caption i,
-.wp-caption > figcaption.wp-caption-text i,
-figcaption i {
-  font-style: normal;
-}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the "related posts" section from the bottom of all article templates (Except those introduced in #21)
- Provides styles for widgets in the "Pre Footer 1" widget area, and for that widget area itself
![Screen Shot 2020-06-04 at 00 19 00](https://user-images.githubusercontent.com/1754187/83715996-ac57d380-a5fc-11ea-9460-79f52ff1cf35.png)
![Screen Shot 2020-06-04 at 00 43 27](https://user-images.githubusercontent.com/1754187/83715998-acf06a00-a5fc-11ea-86ee-b92ddc69ba5a.png)
![Screen Shot 2020-06-04 at 00 43 39](https://user-images.githubusercontent.com/1754187/83715999-ad890080-a5fc-11ea-92b3-a35ab5dd423e.png)
![Screen Shot 2020-06-04 at 00 43 56](https://user-images.githubusercontent.com/1754187/83716000-ae219700-a5fc-11ea-8937-44851818062f.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #10 

## Testing/Questions

Features that this PR affects:

- article pages
- the widget area

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Do we need better styles anywhere

Steps to test this PR:

1. Add a "Related Posts by Taxonomy" widget to the Pre Footer 1 widget area, set to show 4 posts, by the Categories taxonomy, showing posts, in link format, with or without post date. Thumbnail settings are irrelevant because the "Link" format is chosen.