### PR TITLE
Italicize captions, unitalicize italics within captions.

### DIFF
--- a/style.css
+++ b/style.css
@@ -113,3 +113,17 @@ body:not(.home).single .entry-content span {
     margin-bottom: 3rem;
   }
 }
+/* https://github.com/INN/theme-calhealthreport/issues/13 */
+.wp-caption,
+.wp-caption > figcaption.wp-caption-text,
+figcaption {
+  font-style: italic;
+}
+.wp-caption em,
+.wp-caption > figcaption.wp-caption-text em,
+figcaption em,
+.wp-caption i,
+.wp-caption > figcaption.wp-caption-text i,
+figcaption i {
+  font-style: normal;
+}


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Italicizes image captions
- For `em` and `i` elements within an italicized image caption, un-italicizes them so that there remains a visual distinction between `em`/`i` text and "normal" text. 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #13

## Testing/Questions

Features that this PR affects:

- captions on images in posts

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Does the de-italicization bit make sense? There are a lot of captions which were manually italicized with `em` tags, and this would make those captions appear not-italic until those styles were removed

Steps to test this PR:

1. Visit a post with uploaded images, in the Block Editor or Classic Editor