### PR TITLE
Narrower article Body Width, reduced article font size, typofix

### DIFF
--- a/style.css
+++ b/style.css
@@ -136,15 +136,6 @@ body:not(.home).single .entry-content span {
 figcaption {
   font-style: italic;
 }
-.wp-caption em,
-.wp-caption > figcaption.wp-caption-text em,
-figcaption em,
-.wp-caption i,
-.wp-caption > figcaption.wp-caption-text i,
-figcaption i {
-  font-style: normal;
-}
-
 
 /*
  * footer widget area styles

--- a/style.css
+++ b/style.css
@@ -143,6 +143,7 @@ figcaption em,
 .wp-caption > figcaption.wp-caption-text i,
 figcaption i {
   font-style: normal;
+}
 
 
 /*
@@ -178,7 +179,7 @@ body:not(.home) .pre-footer-widgets {
   margin: 0;
   padding: 0;
 }
-.pre-footer-widgets .related_posts_by_taxonomy li a { 
+.pre-footer-widgets .related_posts_by_taxonomy li a {
   font-size: 1.25rem;
   color: #000;
   font-family: acumin-pro-condensed,"Arial Narrow",Arial,Helvetica,sans-serif !important;

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body:not(.home).single .entry-content a,
 body:not(.home).single .entry-content li, 
 body:not(.home).single .entry-content p, 
 body:not(.home).single .entry-content span {
-  font-size: 1.25rem!important;
+  font-size: 1.125rem!important;
 }
 .post-template-single-full-width-image .photo-header-background {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -124,6 +124,12 @@ body:not(.home).single .entry-content span {
     margin-bottom: 3rem;
   }
 }
+
+/* https://github.com/INN/theme-calhealthreport/issues/25 */
+#single-post.no-sidebar .main-content {
+  max-width: 40rem;
+}
+
 /* https://github.com/INN/theme-calhealthreport/issues/13 */
 .wp-caption,
 .wp-caption > figcaption.wp-caption-text,

--- a/style.css
+++ b/style.css
@@ -163,6 +163,7 @@ body:not(.home) .pre-footer-widgets {
 .pre-footer-widgets .widget > h6 {
   font-size: 1.875rem !important; /* ugh */
 }
+.pre-footer-widgets .related_posts_by_taxonomy div.gallery,
 .pre-footer-widgets .related_posts_by_taxonomy ul { 
   display: flex;
   flex-direction: row;
@@ -173,12 +174,30 @@ body:not(.home) .pre-footer-widgets {
   margin: 0;
   padding: 0;
 }
+.pre-footer-widgets .related_posts_by_taxonomy figure.gallery-item img {
+  max-width: 15rem;
+}
+.pre-footer-widgets .related_posts_by_taxonomy figure.gallery-item,
 .pre-footer-widgets .related_posts_by_taxonomy li { 
-  flex: 1 1 18rem;
+  flex: 1 0 15rem;
   display: block;
-  margin: 0;
+  margin: 0 0 1em 0;
   padding: 0;
 }
+@media ( max-width: 60rem ) and ( min-width: 30rem ) {
+  .pre-footer-widgets .related_posts_by_taxonomy figure.gallery-item,
+  .pre-footer-widgets .related_posts_by_taxonomy li { 
+    flex: 1 0 50%;
+  }
+}
+@media ( max-width: calc( 30rem - 1px ) ) {
+  .pre-footer-widgets .related_posts_by_taxonomy figure.gallery-item img {
+    max-width: 25%;
+    float: left;
+    margin-right: 1em;
+  }
+}
+.pre-footer-widgets .related_posts_by_taxonomy figcaption a,
 .pre-footer-widgets .related_posts_by_taxonomy li a {
   font-size: 1.25rem;
   color: #000;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Reduces the article font size from `1.25rem` = 20px to `1.125rem`= 18px.
- Reduces the article main-column max width from `52.5rem` = 810px to `40rem` = 610px. This is approximately in line with the examples given in https://github.com/INN/theme-calhealthreport/issues/25 which had max widths of 575px and 600px.
- Re-adds a missing `}` identified in https://github.com/INN/theme-calhealthreport/pull/24#discussion_r463130345 which was messing with the styles for the footer widget area.

![Screenshot_2020-07-30 At High Risk From Coronavirus, Undocumented Seniors Fear Seeking Medical Care – California Health Rep](https://user-images.githubusercontent.com/1754187/88970166-f0bfc280-d27f-11ea-816b-400733751737.png)
![Screenshot_2020-07-30 Doctor’s Notes COVID-19 May Create Another Public Health Crisis – California Health Report](https://user-images.githubusercontent.com/1754187/88970177-f4534980-d27f-11ea-9413-da91c2168cd2.png)

## Why

For #25 and https://github.com/INN/theme-calhealthreport/issues/13

## Testing/Questions

Features that this PR affects:

- Single article pages

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Are there anything 

Steps to test this PR:

1. Check out this branch, and view:
    - a post with the default template
    - a post with the full-width header template