### PR TITLE
QA items, September 11 email

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,7 +101,7 @@ body:not(.home).single .entry-content span {
 }
 @media (min-width: 768px) {
   .post-template-single-full-width-image .photo-header-background .featured-image-bg-layer {
-    background-color: rgba(0, 0, 0, 0.62);
+    background-color: rgba(0, 0, 0, 0.45);
     position: absolute;
     top: 0;
     left: 0;

--- a/style.css
+++ b/style.css
@@ -117,7 +117,7 @@ body:not(.home).single .entry-content span {
   .post-template-single-full-width-image .photo-header-background figcaption {
     display: none;
   }
-  .post-template-single-full-width-image .bottom-header-content figcaption {
+  .post-template-single-full-width-image .no-sidebar .bottom-header-content figcaption {
     margin-left: calc(50% - 48vw) !important;
     max-width: 98vw;
     width: 50vw;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Decreases the full-width header image's black overlay's opacity from 0.62 to 0.45
- Fixes alignment of figcaption with the full-width header image when there is a sidebar present on the page

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #28

## Testing/Questions

Features that this PR affects:

- Pages with the "Full Width Header Image template", with and without the sidebar shown

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Set up two posts with a full-width header image, with and without sidebar enabled
    - with: http://staging.calhealthreport.flywheelsites.com/2020/05/07/society-designed-the-systems-that-created-covid-19-inequalities-we-can-redesign-them/
    - without: http://staging.calhealthreport.flywheelsites.com/2020/05/19/this-crisis-has-led-to-more-equitable-policies-that-california-should-keep/